### PR TITLE
fix : remove extra * in multiplication operation

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -58,7 +58,7 @@ def multiply(a, b):
     Retourne :
     - (float | int) : Le produit de a et b.
     """
-    return a ** b  # Remarque : utilise l’exponentiation au lieu de la multiplication.
+    return a * b  
 
 
 def divide(a, b):


### PR DESCRIPTION
The multiplication function was using the exponentiation operator (`**`) instead of the multiplication operator (`*`).

As a result, the following tests were failing : 
- test_calculate_multiplication
- test_multiply_positive_numbers
- test_multiply_by_zero
- test_multiply_by_zero_zero
- test_multiply_negative_numbers
- test_multiply_by_one
- test_multiply_floats
- test_multiply_large_numbers

The fix solves all the failing tests related to the multiplication operation. 

The following issues can be closed : 
- [Failed multiplying positive numbers test](https://github.com/WilliamWang5632/TP3---LOG3000/issues/3)
- [Failed test multiplying by zero](https://github.com/WilliamWang5632/TP3---LOG3000/issues/4)
- [Failed test : multiplying zero by zero](https://github.com/WilliamWang5632/TP3---LOG3000/issues/6)
- [Failed test: multiplying negative numbers](https://github.com/WilliamWang5632/TP3---LOG3000/issues/7)
- [Failed test : multiplying by one](https://github.com/WilliamWang5632/TP3---LOG3000/issues/8)
- [Failed test : multiplying floats](https://github.com/WilliamWang5632/TP3---LOG3000/issues/10)
- [Failed test : multiplying large numbers](https://github.com/WilliamWang5632/TP3---LOG3000/issues/11)