### PR TITLE
Fix/ui: Missing operation symboles and typo in numbers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@ et opérateurs, ainsi que la logique JavaScript de base pour la gestion de l’a
          -->
          <div class="buttons">
             <button type="button" class="btn" onclick="appendToDisplay('1')">1</button>
-            <button type="button" class="btn" onclick="appendToDisplay('2')">02</button>
+            <button type="button" class="btn" onclick="appendToDisplay('2')">2</button>
             <button type="button" class="btn" onclick="appendToDisplay('3')">3</button>
             <button type="button" class="btn operator" onclick="appendToDisplay('+')">+</button>
 
@@ -48,14 +48,14 @@ et opérateurs, ainsi que la logique JavaScript de base pour la gestion de l’a
             <button type="button" class="btn operator" onclick="appendToDisplay('-')">-</button>
 
             <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
-            <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
+            <button type="button" class="btn" onclick="appendToDisplay('8')">8</button>
             <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
-            <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
+            <button type="button" class="btn operator" onclick="appendToDisplay('*')">*</button>
 
             <button type="button" class="btn" onclick="appendToDisplay('0')">0</button>
             <button type="button" class="btn" onclick="clearDisplay()">C</button>
             <button type="submit" class="btn operator">=</button>
-            <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+            <button type="button" class="btn operator" onclick="appendToDisplay('/')">/</button>
          </div>
       </form>
    </div>


### PR DESCRIPTION
UI errors were fixed: 02 was replaced by 2 and 88 by 8. The symboles (/) and (x) were also added to the calculator display. 

The following Issue can be closed now:
[Missing operation symboles and typo in numbers](https://github.com/WilliamWang5632/TP3---LOG3000/issues/18) 